### PR TITLE
Use GP3 EBS root volume in Terraform

### DIFF
--- a/packer/wiki.pkr.hcl
+++ b/packer/wiki.pkr.hcl
@@ -31,7 +31,7 @@ variable "aws_region" {
 variable "disk_size" {
   type        = number
   description = "The size of the EBS volume to create."
-  default     = 15
+  default     = 8
 }
 
 variable "aws_access_key" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,8 @@
+variable "server_name" {
+  type = string
+  default = "terraform-gollum-wiki"
+}
+
 variable "aws-region" {
   type    = string
   default = "us-east-2"
@@ -21,4 +26,19 @@ variable "instance_type" {
 variable "tailscale_parameter_name" {
   type    = string
   default = "tailscale"
+}
+
+variable "disk_size" {
+  type = number
+  default = 8
+}
+
+variable "disk_iops" {
+  type = number
+  default = 3000
+}
+
+variable "disk_throughput" {
+  type = number
+  default = 125
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "server_name" {
-  type = string
+  type    = string
   default = "terraform-gollum-wiki"
 }
 
@@ -29,16 +29,16 @@ variable "tailscale_parameter_name" {
 }
 
 variable "disk_size" {
-  type = number
+  type    = number
   default = 8
 }
 
 variable "disk_iops" {
-  type = number
+  type    = number
   default = 3000
 }
 
 variable "disk_throughput" {
-  type = number
+  type    = number
   default = 125
 }

--- a/terraform/wiki.tf
+++ b/terraform/wiki.tf
@@ -9,10 +9,10 @@ resource "aws_spot_instance_request" "wiki" {
 
   root_block_device {
     encrypted   = true
-    volume_size = 15
+    volume_size = var.disk_size
     volume_type = "gp3"
-    iops        = 3000
-    throughput  = 125
+    iops        = var.disk_iops
+    throughput  = var.disk_throughput
     kms_key_id  = data.aws_kms_key.aws-ebs.arn
   }
 
@@ -26,7 +26,7 @@ resource "aws_spot_instance_request" "wiki" {
   spot_type            = "persistent"
 
   tags = {
-    Name = "terraform-gollum-wiki"
+    Name = var.server_name
   }
 
   provisioner "local-exec" {

--- a/terraform/wiki.tf
+++ b/terraform/wiki.tf
@@ -10,6 +10,9 @@ resource "aws_spot_instance_request" "wiki" {
   root_block_device {
     encrypted   = true
     volume_size = 15
+    volume_type = "gp3"
+    iops = 3000
+    throughput = 125
     kms_key_id  = data.aws_kms_key.aws-ebs.arn
   }
 

--- a/terraform/wiki.tf
+++ b/terraform/wiki.tf
@@ -11,8 +11,8 @@ resource "aws_spot_instance_request" "wiki" {
     encrypted   = true
     volume_size = 15
     volume_type = "gp3"
-    iops = 3000
-    throughput = 125
+    iops        = 3000
+    throughput  = 125
     kms_key_id  = data.aws_kms_key.aws-ebs.arn
   }
 


### PR DESCRIPTION
Additionally, based on this disk usage decreasing the default disk size to 8GB. Waste not want not.

```bash
sh-4.2$ df -h
Filesystem        Size  Used Avail Use% Mounted on
devtmpfs          437M     0  437M   0% /dev
tmpfs             478M     0  478M   0% /dev/shm
tmpfs             478M  424K  478M   1% /run
tmpfs             478M     0  478M   0% /sys/fs/cgroup
/dev/nvme0n1p1     15G  3.1G   12G  21% /
/dev/nvme0n1p128   10M  3.7M  6.3M  38% /boot/efi
tmpfs              96M     0   96M   0% /run/user/1000
```
